### PR TITLE
fix cv_bridge library header extension

### DIFF
--- a/oculus_ros2/cfg/default.yaml
+++ b/oculus_ros2/cfg/default.yaml
@@ -25,7 +25,7 @@
 
     gain_assist: True # Enable gain assist. Default value is True.
 
-    range: 20.0 # Sonar range (in meters), min=0.3, max=40.0.  Default value is 20.0.
+    range: 5.0 # Sonar range (in meters) / [min=0.1, max=120.0/40.0 for M750d] / [min=0.1, max=40.0/10.0 for M1200d] / [min=0.1, max=30.0/5.0 for M3000d] / Default value is 20.0.
 
     # These parameters are for scaling data (investigate)
     gamma_correction: 153 # Gamma correction, min=0, max=255.  Default value is 153 (60%).

--- a/oculus_ros2/include/oculus_ros2/sonar_viewer.hpp
+++ b/oculus_ros2/include/oculus_ros2/sonar_viewer.hpp
@@ -33,7 +33,7 @@
 #ifndef OCULUS_ROS2__SONAR_VIEWER_HPP_
 #define OCULUS_ROS2__SONAR_VIEWER_HPP_
 
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <oculus_driver/AsyncService.h>
 #include <oculus_driver/SonarDriver.h>
 

--- a/oculus_ros2/launch/default.launch.py
+++ b/oculus_ros2/launch/default.launch.py
@@ -58,6 +58,22 @@ def generate_launch_description():
         output="screen",
     )
 
-    ld.add_action(oculus_sonar_node)
+    rqt_gui_node = Node(
+        package="rqt_gui",
+        executable="rqt_gui",
+        name="rqt_gui",
+        output="screen"
+    )
 
+    rqt_reconfigure_node = Node(
+        package="rqt_reconfigure",
+        executable="rqt_reconfigure",
+        name="rqt_reconfigure",
+        output="screen"
+    )
+    
+    ld.add_action(oculus_sonar_node)
+    ld.add_action(rqt_gui_node)
+    ld.add_action(rqt_reconfigure_node)
+    
     return ld


### PR DESCRIPTION
@lebarsfa
Update from `#include <cv_bridge/cv_bridge.h>` to `#include <cv_bridge/cv_bridge.hpp>` in `sonar_viewer.hpp` header file.
Library not found otherwise